### PR TITLE
Feature/report superfluous file in dry run

### DIFF
--- a/lib/synx/project.rb
+++ b/lib/synx/project.rb
@@ -151,9 +151,9 @@ module Synx
 
     def exit_code
       if warn_type.to_s == 'error' and sync_issues_repository.issues_count > 0
-        -1
+        false
       else
-        0
+        true
       end
     end
   end

--- a/lib/synx/xcodeproj_ext/project/object/pbx_group.rb
+++ b/lib/synx/xcodeproj_ext/project/object/pbx_group.rb
@@ -122,7 +122,9 @@ module Xcodeproj
             destination.mkpath
             file_utils.mv(file_pathname.realpath, destination)
             if is_file_to_prune
-              Synx::Tabber.puts "#{file_pathname.basename} (source/image file that is not referenced by the Xcode project)".yellow
+              issue = "#{file_pathname.basename} (source/image file that is not referenced by the Xcode project)"
+              project.sync_issues_repository.add_issue(issue, file_pathname.basename, :unused)              
+              Synx::Tabber.puts issue.yellow
             else
               Synx::Tabber.puts file_pathname.basename
             end


### PR DESCRIPTION
Report source files that are not referenced by the Xcode project in dry run too.
Also differentiate success and failure in exit code using a bool.